### PR TITLE
Added test counter config

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "author": "Alexey Kureev <a.g.kureev@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "jest": "^26.6.1"
+    "@types/minimist": "^1.2.0",
+    "jest": "^26.6.1",
+    "minimist": "^1.2.5"
   },
   "scripts": {
     "build": "tsc",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,13 +1,25 @@
 #!/usr/bin/env -S node --expose-gc
 
 import * as path from "path";
+import * as parseArgs from "minimist";
 import { run } from "jest";
 
 const config = {
   testSequencer: path.join(__dirname, "sequencer.js"),
 };
 
-let args = [...process.argv.slice(2)];
+let argv = parseArgs(process.argv.slice(2));
+if (argv.cnt) {
+  process.env.cnt = argv.cnt;
+  delete argv.cnt;
+}
+
+let args: string[] = [];
+Object.entries<unknown>(argv).forEach(([key, value]) => {
+  args.push(key);
+  args.push(String(value));
+});
+
 args.push("--config", JSON.stringify(config));
 args.push("--runInBand");
 args.push("--logHeapUsage");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,9 +9,9 @@ const config = {
 };
 
 let argv = parseArgs(process.argv.slice(2));
-if (argv.cnt) {
-  process.env.cnt = argv.cnt;
-  delete argv.cnt;
+if (argv.count) {
+  process.env.count = argv.count;
+  delete argv.count;
 }
 
 let args: string[] = [];

--- a/src/sequencer.ts
+++ b/src/sequencer.ts
@@ -3,7 +3,7 @@ import { Test } from "jest-runner";
 
 class NoDramaSequencer extends Sequencer {
   sort(tests: Test[]): Test[] {
-    return new Array(Number(process.env.cnt) || 10).fill(tests[0]);
+    return new Array(Number(process.env.count) || 10).fill(tests[0]);
   }
 }
 

--- a/src/sequencer.ts
+++ b/src/sequencer.ts
@@ -3,7 +3,7 @@ import { Test } from "jest-runner";
 
 class NoDramaSequencer extends Sequencer {
   sort(tests: Test[]): Test[] {
-    return new Array(10).fill(tests[0]);
+    return new Array(Number(process.env.cnt) || 10).fill(tests[0]);
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -540,6 +540,11 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
+"@types/minimist@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
+  integrity sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
+
 "@types/node@*":
   version "14.14.6"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.6.tgz#146d3da57b3c636cc0d1769396ce1cfa8991147f"


### PR DESCRIPTION
Now developers can configure the number of tests run using `cnt` flag. In some cases (like extremely heavy/long tests), 10 runs might be overkill. I think having this flexibility would help many people.